### PR TITLE
Mutt mailbox fix

### DIFF
--- a/.muttrc
+++ b/.muttrc
@@ -3,6 +3,6 @@ message-hook '~f"^noreply@hashbang\.sh$"~s"^Press Enter to open this!$"~b"will s
     'push ":unset wait_key\n!(sleep 10 && rm $HOME/Mail/*/msg.welcome* 2>/dev/null)&\n:set wait_key\n"'
     
 set mbox_type=Maildir
-set folder=$HOME/mail
+set folder=$HOME/Mail
 set spoolfile=+/
 set header_cache=~/.cache/mutt

--- a/.muttrc
+++ b/.muttrc
@@ -1,3 +1,8 @@
 # Forcibly remove welcome message 10 seconds after opening it
 message-hook '~f"^noreply@hashbang\.sh$"~s"^Press Enter to open this!$"~b"will self-destruct"' \
     'push ":unset wait_key\n!(sleep 10 && rm $HOME/Mail/*/msg.welcome* 2>/dev/null)&\n:set wait_key\n"'
+    
+set mbox_type=Maildir
+set folder=$HOME/mail
+set spoolfile=+/
+set header_cache=~/.cache/mutt


### PR DESCRIPTION
```
set mbox_type=Maildir
set folder=$HOME/Mail
set spoolfile=+/
set header_cache=~/.cache/mutt
```
Fixes the Mutt client (at least partially)