### PR TITLE
Pull in defaults for ZSH and Git

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,18 +1,7 @@
-# Include Grml's gitconfig
-[include]
-	path = ~/.grml-etc-core/etc/skel/.gitconfig
-
 # Those are #!'s customizations
 [push]
         default = simple
 [hub]
         protocol = https
-[alias]
-        br = branch
-        ff = merge --ff-only
-
-        derp = commit --amend --no-edit
-	clean-tags = fetch --all --prune
 
 # Your own customizations come here
-

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,18 @@
+# Include Grml's gitconfig
+[include]
+	path = ~/.grml-etc-core/etc/skel/.gitconfig
+
+# Those are #!'s customizations
+[push]
+        default = simple
+[hub]
+        protocol = https
+[alias]
+        br = branch
+        ff = merge --ff-only
+
+        derp = commit --amend --no-edit
+	clean-tags = fetch --all --prune
+
+# Your own customizations come here
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".grml-etc-core"]
+	path = .grml-etc-core
+	url = https://github.com/grml/grml-etc-core.git

--- a/.zlogin
+++ b/.zlogin
@@ -1,0 +1,17 @@
+#!/bin/zsh
+
+################################################################################
+# This file is sourced only for login shells. It
+# should contain commands that should be executed only
+# in login shells. It should be used to set the terminal
+# type and run a series of external commands (fortune,
+# msgs, from, etc.)
+# Note that using zprofile and zlogin, you are able to
+# run commands for login shells before and after zshrc.
+#
+# Global Order: zshenv, zprofile, zshrc, zlogin
+################################################################################
+
+source ~/.grml-etc-core/etc/zsh/zlogin
+
+# Your custom things come here

--- a/.zlogout
+++ b/.zlogout
@@ -1,0 +1,6 @@
+#!/bin/zsh
+# Shutdown files (.zlogout and zlogout) are run, when a login shell exits.
+
+source ~/.grml-etc-core/etc/zsh/zlogout
+
+# Your custom things come here

--- a/.zprofile
+++ b/.zprofile
@@ -1,0 +1,12 @@
+#!/bin/zsh
+################################################################################
+# This file is sourced only for login shells (i.e. shells
+# invoked with "-" as the first character of argv[0], and
+# shells invoked with the -l flag). It's read after zshenv.
+#
+# Global Order: zshenv, zprofile, zshrc, zlogin
+################################################################################
+
+source ~/.grml-etc-core/etc/zsh/zprofile
+
+# Your custom things come here

--- a/.zshenv
+++ b/.zshenv
@@ -1,0 +1,21 @@
+#!/bin/zsh
+################################################################################
+# This file is sourced on all invocations of the shell.
+# It is the 1st file zsh reads; it's read for every shell,
+# even if started with -f (setopt NO_RCS), all other
+# initialization files are skipped.
+#
+# This file should contain commands to set the command
+# search path, plus other important environment variables.
+# This file should not contain commands that produce
+# output or assume the shell is attached to a tty.
+#
+# Notice: .zshenv is the same, execpt that it's not read
+# if zsh is started with -f
+#
+# Global Order: zshenv, zprofile, zshrc, zlogin
+################################################################################
+
+source ~/.grml-etc-core/etc/zsh/zshenv
+
+# Your custom things come here

--- a/.zshrc
+++ b/.zshrc
@@ -1,0 +1,23 @@
+#!/bin/zsh
+################################################################################
+# This file is sourced only for interactive shells. It
+# should contain commands to set up aliases, functions,
+# options, key bindings, etc.
+#
+# Global Order: zshenv, zprofile, zshrc, zlogin
+################################################################################
+
+# USAGE
+# If you do not want to version your .zshrc customizations with Git,
+#   please use ~/.zshrc.pre and ~/.zshrc.local. The former file is read
+#   before ~/.zshrc, the latter is read after it.
+# Also, consider reading the refcard and the reference manual for
+#   Grml's ZSH setup, which we use, both available from:
+#     <http://grml.org/zsh/>
+
+source ~/.grml-etc-core/etc/zsh/zshrc
+
+# Autoload Grml's functions and completions
+fpath=(~/.grml-etc-core/usr_share_grml/zsh/ $fpath)
+
+# Your custom things come here


### PR DESCRIPTION
This pull request pulls in some default configuration for ZSH and Git, based on [grml's](https://github.com/grml/grml-etc-core).

The choice of basing that config off grml is motivated by several factors:
- it is easy for users who get used to this to pull it in on other systems (it even has a Debian package);
- it is a rather standard ZSH setup, especially for Debian-based systems;
- it is [documented](https://grml.org/zsh/) and rather simple (yes, oh-my-zsh, I'm looking at you...);
- it does not have incompatibilities with ZSH plugin managers, like [antigen](https://github.com/zsh-users/antigen);
- it does not have incompatibilities with pre-canned ZSH frameworks, like [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) or [prezto](sorin-ionescu/prezto), and assorted themes;
- it is lightweight.

_TL;DR_: This is a simple default config, which is helpful but doen't bring in the complexities of behemoths like [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh). Its simplicity and documentation mean that it is suitable for users to customize and improve upon.

_NOTE_: This does _not_ make ZSH the default shell for users.  This is on purpose: we want a rather standard (and sadly, on most Linux distros, bash is standard) setup in which to bring new users.
The goal is to give helpful defaults for users who knew enough to switch their shell to ZSH.