### PR TITLE
New feature urlview in mutt & weechat to open urls

### DIFF
--- a/.muttrc
+++ b/.muttrc
@@ -6,6 +6,3 @@ set mbox_type=Maildir
 set folder=$HOME/Mail
 set spoolfile=+/
 set header_cache=~/.cache/mutt
-
-# ctrl + b to open links
-macro pager \cb <pipe-entry>'urlview'<enter> 'Follow links with urlview'

--- a/.muttrc
+++ b/.muttrc
@@ -6,3 +6,6 @@ set mbox_type=Maildir
 set folder=$HOME/Mail
 set spoolfile=+/
 set header_cache=~/.cache/mutt
+
+# ctrl + b to open links
+macro pager \cb <pipe-entry>'urlview'<enter> 'Follow links with urlview'

--- a/.weechat/python/autoload/urlview.py
+++ b/.weechat/python/autoload/urlview.py
@@ -1,0 +1,1 @@
+../urlview.py

--- a/.weechat/python/urlview.py
+++ b/.weechat/python/urlview.py
@@ -1,0 +1,57 @@
+# This weechat plugin pipes the current weechat buffer through urlview
+#
+# Usage:
+# /urlview
+#
+# History:
+# 10-04-2015
+# Version 1.0.0: initial release
+# Version 1.0.1: reverse text passed to urlview
+# Version 1.0.2: remove weechat color from messages
+
+import distutils.spawn
+import os
+import pipes
+import weechat
+
+
+def urlview(data, buf, args):
+    infolist = weechat.infolist_get("buffer_lines", buf, "")
+    lines = []
+    while weechat.infolist_next(infolist) == 1:
+        lines.append(
+            weechat.string_remove_color(
+                weechat.infolist_string(infolist, "message"),
+                ""
+            )
+        )
+
+    weechat.infolist_free(infolist)
+
+    if not lines:
+        weechat.prnt(buf, "No URLs found")
+        return weechat.WEECHAT_RC_OK
+
+    text = "\n".join(reversed(lines))
+    response = os.system("echo %s | urlview" % pipes.quote(text))
+    if response != 0:
+        weechat.prnt(buf, "No URLs found")
+
+    weechat.command(buf, "/window refresh")
+
+    return weechat.WEECHAT_RC_OK
+
+
+def main():
+    if distutils.spawn.find_executable("urlview") is None:
+        return weechat.WEECHAT_RC_ERROR
+
+    if not weechat.register("urlview", "Keith Smiley", "1.0.2", "MIT",
+                            "Use urlview on the current buffer", "", ""):
+        return weechat.WEECHAT_RC_ERROR
+
+    weechat.hook_command("urlview", "Pass the current buffer to urlview", "",
+                         "", "", "urlview", "")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR will introduce the use of urlview in Weechat and Mutt.

urlview will extract URLs from text within the current Weechat buffer or email in Mutt and display a menu from which you may select the desired link and launch from within the shell using Lynx. In the case of multiple URLs in buffer/email, it will allow you to select the desired URL from a list.

In #! and #!social multiple links will often be the case due to URL shortener, but should not pose any issue.

_Weechat Use_ 
/urlview

_Mutt Use_ (listed in .muttrc)
ctrl + b

I can also add something to man.


