### PR TITLE
Add GnuPG configuration

### DIFF
--- a/.gnupg/gpg.conf
+++ b/.gnupg/gpg.conf
@@ -1,0 +1,86 @@
+#
+# This is an implementation of the Riseup OpenPGP Best Practices
+# https://help.riseup.net/en/security/message-security/openpgp/best-practices
+# Shamelessly stolen from Jake Applebaum's duraconf
+#
+
+#-----------------------------
+# options for keysigning
+#-----------------------------
+
+ask-cert-level
+default-cert-level 2
+
+#-----------------------------
+# default key
+#-----------------------------
+
+# The default key to sign with. If this option is not used, the default key is
+# the first key found in the secret keyring
+
+#default-key 0x700E88FC14B533111AD7A40F1D7C08C6CC263D74
+
+#-----------------------------
+# behavior
+#-----------------------------
+
+# Don't autocheck the trust DB, this is super-slow
+# auto-check-trustdb
+
+# Disable inclusion of the version string in ASCII armored output
+no-emit-version
+
+# Disable comment string in clear text signatures and ASCII armored messages
+no-comments
+
+# Display long key IDs
+keyid-format 0xlong
+
+# List all keys (or the specified ones) along with their fingerprints
+with-fingerprint
+
+# Display the calculated validity of user IDs during key listings
+list-options   show-uid-validity
+verify-options show-uid-validity
+
+# Try to use the GnuPG-Agent. With this option, GnuPG first tries to connect to
+# the agent before it asks for a passphrase.
+use-agent
+
+
+#-----------------------------
+# keyserver options
+#-----------------------------
+
+# When using --refresh-keys, if the key in question has a preferred keyserver
+# URL, then disable use of that preferred keyserver to refresh the key from
+keyserver-options no-honor-keyserver-url
+
+# When searching for a key with --search-keys, include keys that are marked on
+# the keyserver as revoked
+keyserver-options include-revoked
+
+# When checking a sig, automatically fetch the key
+#keyserver-options auto-key-retrieve
+
+#-----------------------------
+# algorithm and ciphers
+#-----------------------------
+
+# list of personal cipher preferences. When multiple ciphers are supported by
+# all recipients, choose the strongest one
+personal-cipher-preferences AES AES256 AES192
+
+# list of personal digest preferences. When multiple digests are supported by
+# all recipients, choose the strongest one
+personal-digest-preferences SHA512 SHA384 SHA256 SHA224
+
+# message digest algorithm used when signing a key
+cert-digest-algo SHA512
+
+# This preference list is used for new keys and becomes the default for
+# "setpref" in the edit menu
+default-preference-list SHA512 SHA384 SHA256 SHA224 AES AES256 AES192 ZLIB BZIP2 ZIP Uncompressed
+
+keyring /usr/share/keyrings/debian-keyring.gpg
+keyring /usr/share/keyrings/debian-role-keys.gpg

--- a/.gnupg/gpg.conf
+++ b/.gnupg/gpg.conf
@@ -82,5 +82,16 @@ cert-digest-algo SHA512
 # "setpref" in the edit menu
 default-preference-list SHA512 SHA384 SHA256 SHA224 AES AES256 AES192 ZLIB BZIP2 ZIP Uncompressed
 
+
+#-----------------------------
+# Debian keyrings
+#-----------------------------
+
+# Use read-only, system-wide keyrings for the Debian keys. In order:
+# - Debian Developers, uploading and non-uploading
+# - Debian Maintainers
+# - Debian “role keys” (ftpmaster, archive signing, ...)
 keyring /usr/share/keyrings/debian-keyring.gpg
+keyring /usr/share/keyrings/debian-nonupload.gpg
+keyring /usr/share/keyrings/debian-maintainers.gpg
 keyring /usr/share/keyrings/debian-role-keys.gpg


### PR DESCRIPTION
Based on recommendations from [RiseUp](https://help.riseup.net/en/security/message-security/openpgp/best-practices) and [Jake Applebaum](https://github.com/ioerror/duraconf/blob/master/configs/gnupg/gpg.conf).

This makes the assumption we deploy the `debian-keyring` package.