### PR TITLE
.tmux.conf: set $TERM to tmux-256color

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,5 +1,5 @@
 # assume 256 colors
-set -g default-terminal "screen-256color"
+set -g default-terminal "tmux-256color"
 
 # default statusbar colors
 set-option -g status-bg colour235 #base02


### PR DESCRIPTION
Debian Jessie has a recent set of terminfos that includes tmux-256color.
This, in particular, allows for the display of italics in terminals that support it.

This may break applications that check `$TERM` specifically, such as vim's mouse support.