### PR TITLE
git: Add git-fixup

### DIFF
--- a/git/.local/bin/git-fixup
+++ b/git/.local/bin/git-fixup
@@ -1,0 +1,24 @@
+#!/bin/sh -e
+# Inspired by Fillipo Valsorda, but more portable:
+#  https://blog.filippo.io/git-fixup-amending-an-older-commit/
+
+help() {
+    echo "git fixup <commit> [git-commit options...]"
+    echo "git-fixup introduces new changes in an older commit"
+    echo "  and rewrites (rebase) the git history."
+}
+
+if [ $# -eq 0 ]; then
+    help
+    exit 1
+elif [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    help
+    exit 0
+fi
+
+EDITOR=true                  # Suppress the editor
+TARGET=$(git rev-parse "$1") # Commit hash to fixup
+shift
+
+git commit --fixup="$TARGET" "$@"
+git rebase -i --autostash --autosquash "$TARGET^"

--- a/git/.local/bin/git-fixup
+++ b/git/.local/bin/git-fixup
@@ -20,5 +20,5 @@ EDITOR=true                  # Suppress the editor
 TARGET=$(git rev-parse "$1") # Commit hash to fixup
 shift
 
-git commit --fixup="$TARGET" "$@"
+git -c commit.gpgSign=false commit --fixup="$TARGET" "$@"
 git rebase -i --autostash --autosquash "$TARGET^"


### PR DESCRIPTION
That's a convenient git command I [borrowed](https://blog.filippo.io/git-fixup-amending-an-older-commit/) from @FiloSottile.

- Modified to work on other shells than bash
- Modified not to run in the user's shell (but in a separate `sh`)  
  This avoids clobbering the user's environment
- Added an help message
- Reliably error-out