### PR TITLE
Set "sent" folder for Mutt

### DIFF
--- a/hashbang/.muttrc
+++ b/hashbang/.muttrc
@@ -5,4 +5,5 @@ message-hook '~f"^noreply@hashbang\.sh$"~s"^Press Enter to open this!$"~b"will s
 set mbox_type=Maildir
 set folder=$HOME/Mail
 set spoolfile=+/
+set record=+/sent
 set header_cache=~/.cache/mutt


### PR DESCRIPTION
As discussed on IRC, the default `~/sent` folder causes problems for new users who get "read only filesystem" errors. This change puts the sent folder inside the maildir which is configured as `~/Mail`.