### PR TITLE
weechat.conf: Make WeeChat's title bar resize if required

### DIFF
--- a/weechat/.weechat/weechat.conf
+++ b/weechat/.weechat/weechat.conf
@@ -295,7 +295,7 @@ title.items = "buffer_title"
 title.position = top
 title.priority = 500
 title.separator = off
-title.size = 1
+title.size = 0
 title.size_max = 0
 title.type = window
 


### PR DESCRIPTION
This helps show the full topic, so users don't miss out on important information.