### PR TITLE
initialize bash env completely before bootstrapping tmux

### DIFF
--- a/bash/.bash_profile
+++ b/bash/.bash_profile
@@ -6,5 +6,5 @@ export VISUAL=$EDITOR
 
 # make sure this is an interactive session, then start tmux
 [[ $- != *i* ]] && return
-[[ -z "$TMUX" ]] && ~/.tmux_bootstrap
 [[ -f "$HOME/.bashrc" ]] && . "$HOME/.bashrc"
+[[ -z "$TMUX" ]] && ~/.tmux_bootstrap


### PR DESCRIPTION
from #! irc:

00:03 sjas https://github.com/hashbang/dotfiles/blob/master/bash/.bash_profile#L9 whats the reasoning behind first starting tmux and afterwards loading ~/.bashrc ?
00:36 mayli bug
